### PR TITLE
Lower the required GAP version to 4.10.0

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -18,6 +18,7 @@ jobs:
           - ubuntu
         gap-branch:
           - master
+          - stable-4.10
           - stable-4.11
           - stable-4.12
           - stable-4.13

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -67,7 +67,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.11.0",
+  GAP := ">= 4.10.0",
   NeededOtherPackages := [],
   SuggestedOtherPackages := [],
   ExternalConditions := [],

--- a/gap/dot.gi
+++ b/gap/dot.gi
@@ -1218,6 +1218,9 @@ graph -> StringFormatted("// {} context \n", GraphvizName(graph)));
 BindGlobal("GV_StringifyNodeName",
 function(node)
   local name, old;
+  if not IsBoundGlobal("Last") then
+    Last := x -> x[Length(x)];
+  fi;
 
   Assert(0, IsGVNode(node));
   name  := GraphvizName(node);


### PR DESCRIPTION
This commit lowers the required version of GAP from 4.11.0 to 4.10.0 to match the min. required version in Digraphs. If we don't do this, then we will have to raise the min. required version in Digraphs to 4.11.0, which doesn't seem necessary (since graphviz works just fine with GAP 4.10.0).