### PR TITLE
fixing removal of attributes from graphs - #23

### DIFF
--- a/gap/dot.gi
+++ b/gap/dot.gi
@@ -542,7 +542,7 @@ InstallMethod(GraphvizRemoveAttr,
 function(obj, attr)
   local attrs;
   attrs      := GraphvizAttrs(obj);
-  obj!.Attrs := Filtered(attrs, item -> item[1] <> String(attr));
+  obj!.Attrs := Filtered(attrs, item -> item <> String(attr));
   return obj;
 end);
 

--- a/gap/dot.gi
+++ b/gap/dot.gi
@@ -540,9 +540,33 @@ InstallMethod(GraphvizRemoveAttr,
 "for a graphviz (di)graph or context and an object",
 [IsGraphvizGraphDigraphOrContext, IsObject],
 function(obj, attr)
-  local attrs;
-  attrs      := GraphvizAttrs(obj);
-  obj!.Attrs := Filtered(attrs, item -> item <> String(attr));
+  local attrs, i, match;
+  attrs := GraphvizAttrs(obj);
+  attr  := String(attr);
+
+  # checks if they attribute names match the one being removed
+  match := function(key, str)
+    for i in [1 .. Length(key)] do
+      if i > Length(str) or key[i] <> str[i] then
+        return false;
+      fi;
+    od;
+
+    i := i + 1;
+    while i <= Length(str) do
+      if str[i] = '=' then
+        return true;
+      elif str[i] <> '\s' and str[i] <> '\t' then
+        return false;
+      fi;
+      i := i + 1;
+    od;
+
+    # attributes which are not key value
+    return true;
+  end;
+
+  obj!.Attrs := Filtered(attrs, s -> not match(attr, s));
   return obj;
 end);
 

--- a/gap/dot.gi
+++ b/gap/dot.gi
@@ -562,7 +562,7 @@ function(obj, attr)
       i := i + 1;
     od;
 
-    # attributes which are not key value
+    # attributes which are not key value or removal by value
     return true;
   end;
 

--- a/tst/graph.tst
+++ b/tst/graph.tst
@@ -250,11 +250,11 @@ gap> GraphvizAttrs(g);
 gap> GraphvizRemoveAttr(g, "1=2");
 <graphviz graph with 0 nodes and 0 edges>
 gap> GraphvizAttrs(g);
-[ "label=test", "1=2" ]
+[ "label=test" ]
 gap> GraphvizRemoveAttr(g, "1");
 <graphviz graph with 0 nodes and 0 edges>
 gap> GraphvizAttrs(g);
-[ "label=test", "1=2" ]
+[ "label=test" ]
 
 # Test set color (graph)
 gap> g := GraphvizGraph();;

--- a/tst/graph.tst
+++ b/tst/graph.tst
@@ -247,14 +247,30 @@ gap> GraphvizSetAttr(g, 1, 2);
 <graphviz graph with 0 nodes and 0 edges>
 gap> GraphvizAttrs(g);
 [ "label=test", "1=2" ]
+gap> GraphvizRemoveAttr(g, "label=tes");;
+gap> GraphvizAttrs(g);
+[ "label=test", "1=2" ]
 gap> GraphvizRemoveAttr(g, "1=2");
 <graphviz graph with 0 nodes and 0 edges>
 gap> GraphvizAttrs(g);
 [ "label=test" ]
+gap> GraphvizSetAttr(g, 1, 2);;
+#I  unknown attribute "1", the graphviz object may no longer be valid, it can be removed using GraphvizRemoveAttr
+gap> GraphvizAttrs(g);
+[ "label=test", "1=2" ]
 gap> GraphvizRemoveAttr(g, "1");
 <graphviz graph with 0 nodes and 0 edges>
 gap> GraphvizAttrs(g);
 [ "label=test" ]
+gap> GraphvizRemoveAttr(g, "label");;
+gap> GraphvizAttrs(g);
+[  ]
+gap> GraphvizSetAttr(g, "label", "test");;
+gap> GraphvizAttrs(g);
+[ "label=test" ]
+gap> GraphvizRemoveAttr(g, "label=test");;
+gap> GraphvizAttrs(g);
+[  ]
 
 # Test set color (graph)
 gap> g := GraphvizGraph();;


### PR DESCRIPTION
- **fixing error in node removal code**
- **added support for removal by both key and value from graph attributes**
- **fixing comment**

Issue: #23
 - fixed removal of attributes from graph / graph like graphviz objects.
 - added support for removal by key (ex. "label") and by entire value (ex. "label=test").
 - updated some tests.
